### PR TITLE
remove full lodash in favour of lodash.debounce

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3916,7 +3916,13 @@
     "lodash": {
       "version": "4.17.15",
       "resolved": "http://storage.mds.yandex.net/get-npm/1890008/lodash-4.17.15.tgz",
-      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
+      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
+      "dev": true
+    },
+    "lodash.debounce": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
+      "integrity": "sha1-gteb/zCmfEAF/9XiUVMArZyk168="
     },
     "lodash.sortby": {
       "version": "4.7.0",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   "dependencies": {
     "chalk": "^2.4.2",
     "commander": "^3.0.0",
-    "lodash": "^4.17.15",
+    "lodash.debounce": "^4.0.8",
     "md5": "^2.2.1",
     "parse-gitignore": "^1.0.1",
     "rsync": "^0.6.1",

--- a/src/utils/getSyncFunc.js
+++ b/src/utils/getSyncFunc.js
@@ -1,5 +1,5 @@
 const chalk = require('chalk');
-const {debounce} = require('lodash');
+const debounce = require('lodash.debounce');
 
 const log = require('./log');
 

--- a/src/utils/parseConfig.js
+++ b/src/utils/parseConfig.js
@@ -1,5 +1,3 @@
-const _ = require('lodash');
-
 const validatePresetConfig = require('./validatePresetConfig');
 const log = require('./log');
 
@@ -14,6 +12,8 @@ const DEFAULT_CONFIG = {
     showRsyncCommand: false,
 };
 const CONFIG_NAME = '.synd.config.js';
+
+const omitServerProp = ({server, ...rest}) => rest;
 
 const parseConfig = (syndConfig, name) => {
     if (!(name in syndConfig)) {
@@ -30,7 +30,7 @@ const parseConfig = (syndConfig, name) => {
             ? `${presetConfig.server}:${presetConfig.dest}`
             : presetConfig.dest;
 
-    return {...DEFAULT_CONFIG, ..._.omit(presetConfig, ['server']), dest, name};
+    return {...DEFAULT_CONFIG, ...omitServerProp(presetConfig), dest, name};
 };
 
 module.exports = parseConfig;


### PR DESCRIPTION
Removal of unnecessary dependency code. Makes synd over 2x times smaller overall according to [bundlephobia](https://bundlephobia.com/result?p=synd@0.0.6)